### PR TITLE
설정 화면을 구성한다.

### DIFF
--- a/core/designsystem/src/main/res/drawable/ic_arrow_right_24.xml
+++ b/core/designsystem/src/main/res/drawable/ic_arrow_right_24.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group>
+        <clip-path android:pathData="M0,0h24v24h-24z" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M10.75,20.13L12.52,21.9L22.42,12L12.52,2.1L10.75,3.87L18.88,12L10.75,20.13Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/java/com/jslee/core/ui/base/BaseViewHolder.kt
+++ b/core/ui/src/main/java/com/jslee/core/ui/base/BaseViewHolder.kt
@@ -17,7 +17,8 @@ abstract class BaseViewHolder<out T>(
     /* must implement */
     open fun bindItems(item: @UnsafeVariance T) {}
 
-    private fun getItem(position: Int): Any? {
+    @PublishedApi
+    internal fun getItem(position: Int): Any? {
         return when (val adapter = bindingAdapter) {
             is ListAdapter<*, *> -> {
                 adapter.currentList[position]
@@ -34,7 +35,7 @@ abstract class BaseViewHolder<out T>(
     }
 
     @Suppress("UNCHECKED_CAST")
-    protected fun getItem(
+    inline fun getItem(
         position: Int = bindingAdapterPosition,
         action: (item: T) -> Unit,
     ) {

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsDetailFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsDetailFragment.kt
@@ -1,8 +1,11 @@
 package com.jslee.presentation.feature.settings
 
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.jslee.core.ui.base.view.BaseFragment
 import com.jslee.presentation.R
 import com.jslee.presentation.databinding.FragmentSettingsDetailBinding
+import com.jslee.presentation.feature.settings.model.navigation.NavigationType
 
 /**
  * MooBeside
@@ -12,5 +15,14 @@ import com.jslee.presentation.databinding.FragmentSettingsDetailBinding
 class SettingsDetailFragment :
     BaseFragment<FragmentSettingsDetailBinding>(R.layout.fragment_settings_detail) {
 
+    private val navArgs by navArgs<SettingsDetailFragmentArgs>()
+
     override fun initViews() {
-    }}
+        val type = navArgs.navigationOption.navigationType
+        binding.toolbarTitle = NavigationType.getDescription(type)
+
+        binding.tbSettingsWebView.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+    }
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsDetailFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsDetailFragment.kt
@@ -1,0 +1,16 @@
+package com.jslee.presentation.feature.settings
+
+import com.jslee.core.ui.base.view.BaseFragment
+import com.jslee.presentation.R
+import com.jslee.presentation.databinding.FragmentSettingsDetailBinding
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+class SettingsDetailFragment :
+    BaseFragment<FragmentSettingsDetailBinding>(R.layout.fragment_settings_detail) {
+
+    override fun initViews() {
+    }}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
@@ -17,7 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class SettingsFragment : BaseFragment<FragmentSettingsBinding>(R.layout.fragment_settings) {
 
     private val settingsAdapter by lazy { SettingsAdapter() }
-    private val optionsList by lazy { Settings.provideOptions() }
+    private val optionsList by lazy { Settings(requireContext()).provideOptions() }
     override fun initViews() {
         binding.tbSettings.setNavigationOnClickListener {
             findNavController().navigateUp()

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
@@ -7,6 +7,7 @@ import com.jslee.presentation.databinding.FragmentSettingsBinding
 import com.jslee.presentation.feature.settings.adapter.SettingsAdapter
 import com.jslee.presentation.feature.settings.model.Settings
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 /**
  * MooBeside
@@ -16,7 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class SettingsFragment : BaseFragment<FragmentSettingsBinding>(R.layout.fragment_settings) {
 
-    private val settingsAdapter by lazy { SettingsAdapter() }
+    private val settingsAdapter by lazy { SettingsAdapter(onOptionClick = ::navigateToOptionDetail) }
     private val optionsList by lazy { Settings(requireContext()).provideOptions() }
     override fun initViews() {
         binding.tbSettings.setNavigationOnClickListener {
@@ -26,5 +27,10 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>(R.layout.fragment
         binding.rvSettings.adapter = settingsAdapter.also {
             it.submitList(optionsList)
         }
+    }
+
+    private fun navigateToOptionDetail(action: Int) {
+        Timber.e("$action")
+//        findNavController().navigate(action)
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
@@ -6,8 +6,9 @@ import com.jslee.presentation.R
 import com.jslee.presentation.databinding.FragmentSettingsBinding
 import com.jslee.presentation.feature.settings.adapter.SettingsAdapter
 import com.jslee.presentation.feature.settings.model.Settings
+import com.jslee.presentation.feature.settings.model.navigation.NavigationOption
+import com.jslee.presentation.feature.settings.model.navigation.NavigationPath
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
 
 /**
  * MooBeside
@@ -29,8 +30,15 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>(R.layout.fragment
         }
     }
 
-    private fun navigateToOptionDetail(action: Int) {
-        Timber.e("$action")
-//        findNavController().navigate(action)
+    private fun navigateToOptionDetail(navigationOption: NavigationOption) {
+        val action = when (navigationOption.navigationPath) {
+            NavigationPath.DETAIL -> SettingsFragmentDirections
+                .actionSettingsToSettingsDetail(navigationOption)
+
+            NavigationPath.WEB_VIEW -> SettingsFragmentDirections
+                .actionSettingsToSettingsWebView(navigationOption)
+        }
+
+        findNavController().navigate(action)
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsFragment.kt
@@ -1,8 +1,11 @@
 package com.jslee.presentation.feature.settings
 
+import androidx.navigation.fragment.findNavController
 import com.jslee.core.ui.base.view.BaseFragment
 import com.jslee.presentation.R
 import com.jslee.presentation.databinding.FragmentSettingsBinding
+import com.jslee.presentation.feature.settings.adapter.SettingsAdapter
+import com.jslee.presentation.feature.settings.model.Settings
 import dagger.hilt.android.AndroidEntryPoint
 
 /**
@@ -12,7 +15,16 @@ import dagger.hilt.android.AndroidEntryPoint
  */
 @AndroidEntryPoint
 class SettingsFragment : BaseFragment<FragmentSettingsBinding>(R.layout.fragment_settings) {
-    override fun initViews() {
 
+    private val settingsAdapter by lazy { SettingsAdapter() }
+    private val optionsList by lazy { Settings.provideOptions() }
+    override fun initViews() {
+        binding.tbSettings.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+
+        binding.rvSettings.adapter = settingsAdapter.also {
+            it.submitList(optionsList)
+        }
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsWebViewFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsWebViewFragment.kt
@@ -1,0 +1,18 @@
+package com.jslee.presentation.feature.settings
+
+import com.jslee.core.ui.base.view.BaseFragment
+import com.jslee.presentation.R
+import com.jslee.presentation.databinding.FragmentSettingsWebViewBinding
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+class SettingsWebViewFragment :
+    BaseFragment<FragmentSettingsWebViewBinding>(R.layout.fragment_settings_web_view) {
+
+    override fun initViews() {
+
+    }
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsWebViewFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/SettingsWebViewFragment.kt
@@ -1,8 +1,11 @@
 package com.jslee.presentation.feature.settings
 
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.jslee.core.ui.base.view.BaseFragment
 import com.jslee.presentation.R
 import com.jslee.presentation.databinding.FragmentSettingsWebViewBinding
+import com.jslee.presentation.feature.settings.model.navigation.NavigationType
 
 /**
  * MooBeside
@@ -12,7 +15,14 @@ import com.jslee.presentation.databinding.FragmentSettingsWebViewBinding
 class SettingsWebViewFragment :
     BaseFragment<FragmentSettingsWebViewBinding>(R.layout.fragment_settings_web_view) {
 
-    override fun initViews() {
+    private val navArgs by navArgs<SettingsWebViewFragmentArgs>()
 
+    override fun initViews() {
+        val type = navArgs.navigationOption.navigationType
+        binding.toolbarTitle = NavigationType.getDescription(type)
+
+        binding.tbSettingsDetail.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/adapter/SettingsAdapter.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/adapter/SettingsAdapter.kt
@@ -1,0 +1,46 @@
+package com.jslee.presentation.feature.settings.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.jslee.core.ui.adapter.MultiViewTypeListAdapter
+import com.jslee.core.ui.base.BaseViewHolder
+import com.jslee.presentation.databinding.ItemDividerBinding
+import com.jslee.presentation.databinding.ItemSettingsHeaderBinding
+import com.jslee.presentation.databinding.ItemSettingsOptionBinding
+import com.jslee.presentation.feature.home.viewholder.divider.DividerViewHolder
+import com.jslee.presentation.feature.settings.model.SettingsListItem
+import com.jslee.presentation.feature.settings.viewholder.SettingsHeaderViewHolder
+import com.jslee.presentation.feature.settings.viewholder.SettingsOptionViewHolder
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+class SettingsAdapter :
+    MultiViewTypeListAdapter<SettingsListItem, SettingsListItem.SettingsViewType>() {
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: SettingsListItem.SettingsViewType,
+    ): BaseViewHolder<SettingsListItem> {
+        val inflater = LayoutInflater.from(parent.context)
+
+        return when (viewType) {
+            SettingsListItem.SettingsViewType.HEADER -> {
+                val binding = ItemSettingsHeaderBinding.inflate(inflater, parent, false)
+                SettingsHeaderViewHolder(binding)
+            }
+
+            SettingsListItem.SettingsViewType.OPTION -> {
+                val binding = ItemSettingsOptionBinding.inflate(inflater, parent, false)
+                SettingsOptionViewHolder(binding)
+            }
+
+            SettingsListItem.SettingsViewType.DIVIDER -> {
+                val binding = ItemDividerBinding.inflate(inflater, parent, false)
+                DividerViewHolder(binding)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/adapter/SettingsAdapter.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/adapter/SettingsAdapter.kt
@@ -7,8 +7,10 @@ import com.jslee.core.ui.base.BaseViewHolder
 import com.jslee.presentation.databinding.ItemDividerBinding
 import com.jslee.presentation.databinding.ItemSettingsHeaderBinding
 import com.jslee.presentation.databinding.ItemSettingsOptionBinding
+import com.jslee.presentation.databinding.ItemSettingsVersionBinding
 import com.jslee.presentation.feature.home.viewholder.divider.DividerViewHolder
 import com.jslee.presentation.feature.settings.model.SettingsListItem
+import com.jslee.presentation.feature.settings.viewholder.SettingsAppVersionViewHolder
 import com.jslee.presentation.feature.settings.viewholder.SettingsHeaderViewHolder
 import com.jslee.presentation.feature.settings.viewholder.SettingsOptionViewHolder
 
@@ -17,8 +19,9 @@ import com.jslee.presentation.feature.settings.viewholder.SettingsOptionViewHold
  * @author jaesung
  * @created 2024/01/08
  */
-class SettingsAdapter :
-    MultiViewTypeListAdapter<SettingsListItem, SettingsListItem.SettingsViewType>() {
+class SettingsAdapter(
+    private val onOptionClick: (action: Int) -> Unit,
+) : MultiViewTypeListAdapter<SettingsListItem, SettingsListItem.SettingsViewType>() {
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -34,7 +37,12 @@ class SettingsAdapter :
 
             SettingsListItem.SettingsViewType.OPTION -> {
                 val binding = ItemSettingsOptionBinding.inflate(inflater, parent, false)
-                SettingsOptionViewHolder(binding)
+                SettingsOptionViewHolder(binding, onOptionClick)
+            }
+
+            SettingsListItem.SettingsViewType.APP_VERSION -> {
+                val binding = ItemSettingsVersionBinding.inflate(inflater, parent, false)
+                SettingsAppVersionViewHolder(binding)
             }
 
             SettingsListItem.SettingsViewType.DIVIDER -> {

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/adapter/SettingsAdapter.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/adapter/SettingsAdapter.kt
@@ -9,6 +9,7 @@ import com.jslee.presentation.databinding.ItemSettingsHeaderBinding
 import com.jslee.presentation.databinding.ItemSettingsOptionBinding
 import com.jslee.presentation.databinding.ItemSettingsVersionBinding
 import com.jslee.presentation.feature.home.viewholder.divider.DividerViewHolder
+import com.jslee.presentation.feature.settings.model.navigation.NavigationOption
 import com.jslee.presentation.feature.settings.model.SettingsListItem
 import com.jslee.presentation.feature.settings.viewholder.SettingsAppVersionViewHolder
 import com.jslee.presentation.feature.settings.viewholder.SettingsHeaderViewHolder
@@ -20,7 +21,7 @@ import com.jslee.presentation.feature.settings.viewholder.SettingsOptionViewHold
  * @created 2024/01/08
  */
 class SettingsAdapter(
-    private val onOptionClick: (action: Int) -> Unit,
+    private val onOptionClick: (NavigationOption) -> Unit,
 ) : MultiViewTypeListAdapter<SettingsListItem, SettingsListItem.SettingsViewType>() {
 
     override fun onCreateViewHolder(

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
@@ -1,0 +1,68 @@
+package com.jslee.presentation.feature.settings.model
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+object Settings {
+
+    fun provideOptions(): List<SettingsListItem> {
+        val options = mutableListOf<SettingsListItem>().apply {
+            add(
+                SettingsListItem.Header(
+                    id = 0,
+                    description = "서비스 이용"
+                )
+            )
+            add(
+                SettingsListItem.Option(
+                    id = 1,
+                    description = "알림설정"
+                )
+            )
+            add(
+                SettingsListItem.Divider(
+                    id = 2,
+                )
+            )
+            add(
+                SettingsListItem.Header(
+                    id = 3,
+                    description = "정보"
+                )
+            )
+            add(
+                SettingsListItem.Option(
+                    id = 4,
+                    description = "공지사항"
+                )
+            )
+            add(
+                SettingsListItem.Option(
+                    id = 5,
+                    description = "서비스 이용약관"
+                )
+            )
+            add(
+                SettingsListItem.Option(
+                    id = 6,
+                    description = "개발자 문의하기"
+                )
+            )
+            add(
+                SettingsListItem.Option(
+                    id = 7,
+                    description = "오픈소스"
+                )
+            )
+            add(
+                SettingsListItem.Option(
+                    id = 8,
+                    description = "버전정보"
+                )
+            )
+        }
+        return options
+    }
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
@@ -3,6 +3,9 @@ package com.jslee.presentation.feature.settings.model
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import com.jslee.presentation.feature.settings.model.navigation.NavigationOption
+import com.jslee.presentation.feature.settings.model.navigation.NavigationPath
+import com.jslee.presentation.feature.settings.model.navigation.NavigationType
 
 /**
  * MooBeside
@@ -22,8 +25,10 @@ class Settings(private val context: Context) {
             add(
                 SettingsListItem.Option(
                     id = 1,
-                    description = "알림설정",
-                    action = 0,
+                    navigationOption = NavigationOption(
+                        navigationType = NavigationType.NOTIFICATION,
+                        navigationPath = NavigationPath.DETAIL,
+                    )
                 )
             )
             add(
@@ -40,29 +45,37 @@ class Settings(private val context: Context) {
             add(
                 SettingsListItem.Option(
                     id = 4,
-                    description = "공지사항",
-                    action = 1,
+                    navigationOption = NavigationOption(
+                        navigationType = NavigationType.NOTICE,
+                        navigationPath = NavigationPath.DETAIL,
+                    )
                 )
             )
             add(
                 SettingsListItem.Option(
                     id = 5,
-                    description = "서비스 이용약관",
-                    action = 2,
+                    navigationOption = NavigationOption(
+                        navigationType = NavigationType.TERMS_OF_SERVICE,
+                        navigationPath = NavigationPath.WEB_VIEW,
+                    )
                 )
             )
             add(
                 SettingsListItem.Option(
                     id = 6,
-                    description = "개발자 문의하기",
-                    action = 3,
+                    navigationOption = NavigationOption(
+                        navigationType = NavigationType.CONTACT,
+                        navigationPath = NavigationPath.WEB_VIEW,
+                    )
                 )
             )
             add(
                 SettingsListItem.Option(
                     id = 7,
-                    description = "오픈소스",
-                    action = 4,
+                    navigationOption = NavigationOption(
+                        navigationType = NavigationType.OPEN_SOURCE,
+                        navigationPath = NavigationPath.DETAIL,
+                    )
                 )
             )
             add(

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
@@ -1,11 +1,15 @@
 package com.jslee.presentation.feature.settings.model
 
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+
 /**
  * MooBeside
  * @author jaesung
  * @created 2024/01/08
  */
-object Settings {
+class Settings(private val context: Context) {
 
     fun provideOptions(): List<SettingsListItem> {
         val options = mutableListOf<SettingsListItem>().apply {
@@ -57,12 +61,25 @@ object Settings {
                 )
             )
             add(
-                SettingsListItem.Option(
+                SettingsListItem.AppVersion(
                     id = 8,
-                    description = "버전정보"
+                    description = "버전정보",
+                    appVersion = getVersionName()
                 )
             )
         }
         return options
+    }
+
+    private fun getVersionName(): String {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.applicationContext.packageManager.getPackageInfo(
+                context.packageName, PackageManager.PackageInfoFlags.of(0L)
+            ).versionName
+        } else {
+            context.applicationContext.packageManager.getPackageInfo(
+                context.packageName, 0
+            ).versionName
+        }
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/Settings.kt
@@ -22,7 +22,8 @@ class Settings(private val context: Context) {
             add(
                 SettingsListItem.Option(
                     id = 1,
-                    description = "알림설정"
+                    description = "알림설정",
+                    action = 0,
                 )
             )
             add(
@@ -39,25 +40,29 @@ class Settings(private val context: Context) {
             add(
                 SettingsListItem.Option(
                     id = 4,
-                    description = "공지사항"
+                    description = "공지사항",
+                    action = 1,
                 )
             )
             add(
                 SettingsListItem.Option(
                     id = 5,
-                    description = "서비스 이용약관"
+                    description = "서비스 이용약관",
+                    action = 2,
                 )
             )
             add(
                 SettingsListItem.Option(
                     id = 6,
-                    description = "개발자 문의하기"
+                    description = "개발자 문의하기",
+                    action = 3,
                 )
             )
             add(
                 SettingsListItem.Option(
                     id = 7,
-                    description = "오픈소스"
+                    description = "오픈소스",
+                    action = 4,
                 )
             )
             add(

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
@@ -1,6 +1,7 @@
 package com.jslee.presentation.feature.settings.model
 
 import com.jslee.core.ui.model.ListItem
+import com.jslee.presentation.feature.settings.model.navigation.NavigationOption
 
 /**
  * MooBeside
@@ -23,8 +24,7 @@ sealed class SettingsListItem(override val viewType: SettingsViewType) : ListIte
 
     data class Option(
         override val id: Long,
-        val description: String,
-        val action: Int,
+        val navigationOption: NavigationOption,
     ) : SettingsListItem(SettingsViewType.OPTION)
 
     data class AppVersion(

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
@@ -12,6 +12,7 @@ sealed class SettingsListItem(override val viewType: SettingsViewType) : ListIte
     enum class SettingsViewType {
         HEADER,
         OPTION,
+        APP_VERSION,
         DIVIDER;
     }
 
@@ -24,6 +25,12 @@ sealed class SettingsListItem(override val viewType: SettingsViewType) : ListIte
         override val id: Long,
         val description: String,
     ) : SettingsListItem(SettingsViewType.OPTION)
+
+    data class AppVersion(
+        override val id: Long,
+        val description: String,
+        val appVersion: String,
+    ) : SettingsListItem(SettingsViewType.APP_VERSION)
 
     data class Divider(
         override val id: Long,

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
@@ -24,6 +24,7 @@ sealed class SettingsListItem(override val viewType: SettingsViewType) : ListIte
     data class Option(
         override val id: Long,
         val description: String,
+        val action: Int,
     ) : SettingsListItem(SettingsViewType.OPTION)
 
     data class AppVersion(

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/SettingsListItem.kt
@@ -1,0 +1,31 @@
+package com.jslee.presentation.feature.settings.model
+
+import com.jslee.core.ui.model.ListItem
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+sealed class SettingsListItem(override val viewType: SettingsViewType) : ListItem {
+
+    enum class SettingsViewType {
+        HEADER,
+        OPTION,
+        DIVIDER;
+    }
+
+    data class Header(
+        override val id: Long,
+        val description: String,
+    ) : SettingsListItem(SettingsViewType.HEADER)
+
+    data class Option(
+        override val id: Long,
+        val description: String,
+    ) : SettingsListItem(SettingsViewType.OPTION)
+
+    data class Divider(
+        override val id: Long,
+    ) : SettingsListItem(SettingsViewType.DIVIDER)
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/navigation/NavigationOption.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/navigation/NavigationOption.kt
@@ -1,0 +1,15 @@
+package com.jslee.presentation.feature.settings.model.navigation
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+@Parcelize
+data class NavigationOption(
+    val navigationType: NavigationType,
+    val navigationPath: NavigationPath,
+) : Parcelable

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/navigation/NavigationPath.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/navigation/NavigationPath.kt
@@ -1,0 +1,10 @@
+package com.jslee.presentation.feature.settings.model.navigation
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+enum class NavigationPath {
+    DETAIL, WEB_VIEW;
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/model/navigation/NavigationType.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/model/navigation/NavigationType.kt
@@ -1,0 +1,26 @@
+package com.jslee.presentation.feature.settings.model.navigation
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+enum class NavigationType(private val description: String) {
+    NOTIFICATION("알림설정"),
+    NOTICE("공지사항"),
+    TERMS_OF_SERVICE("서비스 이용약관"),
+    CONTACT("개발자 문의하기"),
+    OPEN_SOURCE("오픈소스");
+
+    companion object {
+        fun getDescription(navType: NavigationType): String {
+            return when (navType) {
+                NOTIFICATION -> NOTIFICATION.description
+                NOTICE -> NOTICE.description
+                TERMS_OF_SERVICE -> TERMS_OF_SERVICE.description
+                CONTACT -> CONTACT.description
+                OPEN_SOURCE -> OPEN_SOURCE.description
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsAppVersionViewHolder.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsAppVersionViewHolder.kt
@@ -1,0 +1,21 @@
+package com.jslee.presentation.feature.settings.viewholder
+
+import com.jslee.core.ui.base.BaseViewHolder
+import com.jslee.presentation.databinding.ItemSettingsHeaderBinding
+import com.jslee.presentation.databinding.ItemSettingsVersionBinding
+import com.jslee.presentation.feature.settings.model.SettingsListItem
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+class SettingsAppVersionViewHolder(
+    private val binding: ItemSettingsVersionBinding,
+) : BaseViewHolder<SettingsListItem.AppVersion>(binding) {
+
+    override fun bindItems(item: SettingsListItem.AppVersion) {
+        binding.tvOptionContent.text = item.description
+        binding.tvVersion.text = item.appVersion
+    }
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsHeaderViewHolder.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsHeaderViewHolder.kt
@@ -1,0 +1,19 @@
+package com.jslee.presentation.feature.settings.viewholder
+
+import com.jslee.core.ui.base.BaseViewHolder
+import com.jslee.presentation.databinding.ItemSettingsHeaderBinding
+import com.jslee.presentation.feature.settings.model.SettingsListItem
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+class SettingsHeaderViewHolder(
+    private val binding: ItemSettingsHeaderBinding,
+) : BaseViewHolder<SettingsListItem.Header>(binding) {
+
+    override fun bindItems(item: SettingsListItem.Header) {
+        binding.tvOptionHeader.text = item.description
+    }
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsOptionViewHolder.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsOptionViewHolder.kt
@@ -3,6 +3,8 @@ package com.jslee.presentation.feature.settings.viewholder
 import com.jslee.core.ui.base.BaseViewHolder
 import com.jslee.presentation.databinding.ItemSettingsOptionBinding
 import com.jslee.presentation.feature.settings.model.SettingsListItem
+import com.jslee.presentation.feature.settings.model.navigation.NavigationOption
+import com.jslee.presentation.feature.settings.model.navigation.NavigationType
 
 /**
  * MooBeside
@@ -11,18 +13,19 @@ import com.jslee.presentation.feature.settings.model.SettingsListItem
  */
 class SettingsOptionViewHolder(
     private val binding: ItemSettingsOptionBinding,
-    private val onOptionClick: (action: Int) -> Unit,
+    private val onOptionClick: (NavigationOption) -> Unit,
 ) : BaseViewHolder<SettingsListItem.Option>(binding) {
 
     init {
         binding.root.setOnClickListener {
             getItem { item ->
-                onOptionClick(item.action)
+                onOptionClick(item.navigationOption)
             }
         }
     }
 
     override fun bindItems(item: SettingsListItem.Option) {
-        binding.tvOptionContent.text = item.description
+        val description = NavigationType.getDescription(item.navigationOption.navigationType)
+        binding.tvOptionContent.text = description
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsOptionViewHolder.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsOptionViewHolder.kt
@@ -11,7 +11,16 @@ import com.jslee.presentation.feature.settings.model.SettingsListItem
  */
 class SettingsOptionViewHolder(
     private val binding: ItemSettingsOptionBinding,
+    private val onOptionClick: (action: Int) -> Unit,
 ) : BaseViewHolder<SettingsListItem.Option>(binding) {
+
+    init {
+        binding.root.setOnClickListener {
+            getItem { item ->
+                onOptionClick(item.action)
+            }
+        }
+    }
 
     override fun bindItems(item: SettingsListItem.Option) {
         binding.tvOptionContent.text = item.description

--- a/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsOptionViewHolder.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/settings/viewholder/SettingsOptionViewHolder.kt
@@ -1,0 +1,19 @@
+package com.jslee.presentation.feature.settings.viewholder
+
+import com.jslee.core.ui.base.BaseViewHolder
+import com.jslee.presentation.databinding.ItemSettingsOptionBinding
+import com.jslee.presentation.feature.settings.model.SettingsListItem
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/01/08
+ */
+class SettingsOptionViewHolder(
+    private val binding: ItemSettingsOptionBinding,
+) : BaseViewHolder<SettingsListItem.Option>(binding) {
+
+    override fun bindItems(item: SettingsListItem.Option) {
+        binding.tvOptionContent.text = item.description
+    }
+}

--- a/presentation/src/main/res/layout/fragment_settings.xml
+++ b/presentation/src/main/res/layout/fragment_settings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -9,11 +10,33 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            style="@style/MooBesideTextAppearance.Heading1"
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/abl_settings"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:text="Settings" />
+            android:layout_height="wrap_content"
+            android:background="@color/White"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/tb_settings"
+                style="@style/MooBeside.MaterialToolbar.Back"
+                app:title="설정" />
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_settings"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:orientation="vertical"
+            android:paddingTop="8dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/abl_settings" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>

--- a/presentation/src/main/res/layout/fragment_settings_detail.xml
+++ b/presentation/src/main/res/layout/fragment_settings_detail.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
+        <variable
+            name="toolbarTitle"
+            type="String" />
 
     </data>
 
@@ -9,12 +14,20 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/tv_test"
+        <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:text="상세"/>
+            android:layout_height="wrap_content"
+            android:background="@color/White"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/tb_settings_web_view"
+                style="@style/MooBeside.MaterialToolbar.Back"
+                app:title="@{toolbarTitle}" />
+
+        </com.google.android.material.appbar.AppBarLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_settings_detail.xml
+++ b/presentation/src/main/res/layout/fragment_settings_detail.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_test"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="상세"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_settings_web_view.xml
+++ b/presentation/src/main/res/layout/fragment_settings_web_view.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
+        <variable
+            name="toolbarTitle"
+            type="String" />
 
     </data>
 
@@ -9,12 +14,20 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/tv_test"
+        <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:text="웹뷰"/>
+            android:layout_height="wrap_content"
+            android:background="@color/White"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/tb_settings_detail"
+                style="@style/MooBeside.MaterialToolbar.Back"
+                app:title="@{toolbarTitle}"/>
+
+        </com.google.android.material.appbar.AppBarLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_settings_web_view.xml
+++ b/presentation/src/main/res/layout/fragment_settings_web_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_test"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="웹뷰"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/item_settings_header.xml
+++ b/presentation/src/main/res/layout/item_settings_header.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <TextView
+        android:id="@+id/tv_option_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/MooBesideTextAppearance.Body2"
+        android:textColor="@color/Gray05"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="12dp"
+        tools:text="서비스 이용" />
+</layout>

--- a/presentation/src/main/res/layout/item_settings_option.xml
+++ b/presentation/src/main/res/layout/item_settings_option.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="12dp">
+
+        <TextView
+            android:id="@+id/tv_option_content"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/MooBesideTextAppearance.Body1"
+            android:textColor="@color/Gray03"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/iv_setting_detail"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="알림 설정" />
+
+        <ImageView
+            android:id="@+id/iv_setting_detail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/description_settings_options"
+            android:src="@drawable/ic_arrow_right_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/item_settings_version.xml
+++ b/presentation/src/main/res/layout/item_settings_version.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="12dp">
+
+        <TextView
+            android:id="@+id/tv_option_content"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:textAppearance="@style/MooBesideTextAppearance.Body1"
+            android:textColor="@color/Gray03"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_version"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="버전정보" />
+
+        <TextView
+            android:id="@+id/tv_version"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/MooBesideTextAppearance.Body1"
+            android:textColor="@color/Gray04"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="1.0.0" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/navigation/navigation_home.xml
+++ b/presentation/src/main/res/navigation/navigation_home.xml
@@ -29,7 +29,14 @@
     <fragment
         android:id="@+id/settingsFragment"
         android:name="com.jslee.presentation.feature.settings.SettingsFragment"
-        android:label="SettingsFragment" />
+        android:label="SettingsFragment">
+        <action
+            android:id="@+id/action_settings_to_settingsDetail"
+            app:destination="@id/settingsDetailFragment" />
+        <action
+            android:id="@+id/action_settings_to_settingsWebView"
+            app:destination="@id/settingsWebViewFragment" />
+    </fragment>
     <fragment
         android:id="@+id/nowPlayingFragment"
         android:name="com.jslee.presentation.feature.now.NowPlayingFragment"
@@ -38,5 +45,21 @@
         android:id="@+id/upComingFragment"
         android:name="com.jslee.presentation.feature.upcoming.UpComingFragment"
         android:label="UpComingFragment" />
+    <fragment
+        android:id="@+id/settingsDetailFragment"
+        android:name="com.jslee.presentation.feature.settings.SettingsDetailFragment"
+        android:label="SettingsDetailFragment">
+        <argument
+            android:name="navigationOption"
+            app:argType="com.jslee.presentation.feature.settings.model.navigation.NavigationOption" />
+    </fragment>
+    <fragment
+        android:id="@+id/settingsWebViewFragment"
+        android:name="com.jslee.presentation.feature.settings.SettingsWebViewFragment"
+        android:label="SettingsWebViewFragment">
+        <argument
+            android:name="navigationOption"
+            app:argType="com.jslee.presentation.feature.settings.model.navigation.NavigationOption" />
+    </fragment>
 
 </navigation>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="tooltip_banner_description">TMDB API 서비스를 통해 수집된 정보입니다.</string>
     <string name="description_date_picker">날짜를 선택하는 영역입니다.</string>
     <string name="description_rate">영화 평점을 나타내는 아이콘입니다.</string>
+    <string name="description_settings_options">상세 설정으로 진입합니다.</string>
 
     <!-- action -->
     <string name="action_share_chooser_title">[무비사이드] %s 링크</string>


### PR DESCRIPTION
### Issue
- close #99 

### 작업 내역 (Required)
- 웹뷰로 띄울 옵션, 네이티브로 띄울 옵션 분리
- 웹뷰 스크린, 네이티브 스크린 생성
- 옵션 타입별 네이티브 스크린 재사용하도록 구현
- 버전 정보 호출 후 설정화면에 표시
- getItem 메서드 inline 처리

### Screenshot
Before | After
:--: | :--:
<img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/084ce1d8-8778-4245-8865-67f232278dc7" width="300" /> | <img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/3f5d1f0c-26da-42fe-a327-283880333ef9" width="300" />

### 관련 링크
- none