### PR TITLE
영화상세, 공유 바텀시트간 뷰모델 공유 문제 해결

### DIFF
--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/MovieDetailFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/MovieDetailFragment.kt
@@ -1,7 +1,7 @@
 package com.jslee.presentation.feature.detail
 
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.jslee.core.external.ExternalLauncher
@@ -32,7 +32,7 @@ class MovieDetailFragment :
     @Inject
     lateinit var externalLauncher: ExternalLauncher
 
-    private val viewModel: MovieDetailViewModel by activityViewModels()
+    private val viewModel: MovieDetailViewModel by viewModels()
     private val safeArgs: MovieDetailFragmentArgs by navArgs()
     private val movieDetailAdapter by lazy {
         MovieDetailAdapter(

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/ShareBottomSheetFragment.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/ShareBottomSheetFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.core.app.ShareCompat
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.jslee.core.ui.extension.showToast
 import com.jslee.presentation.R
@@ -25,7 +25,7 @@ class ShareBottomSheetFragment : BottomSheetDialogFragment() {
     private var _binding: DialogShareBottomSheetBinding? = null
     val binding: DialogShareBottomSheetBinding get() = requireNotNull(_binding)
 
-    private val viewModel: MovieDetailViewModel by activityViewModels()
+    private val viewModel: MovieDetailViewModel by viewModels(ownerProducer = { requireParentFragment() })
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
### Issue
- close #129 
### 작업 내역 (Required)
- 기존 activityViewModel로 공유하던 뷰모델 인스턴스의 Owner 변경
- fragment-ktx viewmodel의 ownerProducer를 통해 Activity에서 ParentFragment로 Owner 수정

### Screenshot
by activityViewModels | by viewModels(requireParentFragment)
:--: | :--:
<img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/ba3a78c5-0575-4222-a550-c87c9e6c5ba3" width="300" /> | <img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/2667b4cd-90b8-4604-bab2-c30ae21ed30f" width="300" />

### 관련 링크
- https://developer.android.com/topic/libraries/architecture/viewmodel/viewmodel-apis