### PR TITLE
상세화면 뷰타입 별 visibility 처리

### DIFF
--- a/core/ui/src/main/java/com/jslee/core/ui/binding/BindingAdapter.kt
+++ b/core/ui/src/main/java/com/jslee/core/ui/binding/BindingAdapter.kt
@@ -1,5 +1,6 @@
 package com.jslee.core.ui.binding
 
+import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
@@ -73,4 +74,9 @@ fun ImageView.setBookmark(isBookmark: Boolean) {
     } else {
         setImageResource(DR.drawable.ic_heart_24)
     }
+}
+
+@BindingAdapter("layoutVisibility")
+fun View.setLayoutVisibility(hasContent: Boolean) {
+    isVisible = hasContent
 }

--- a/core/ui/src/main/java/com/jslee/core/ui/binding/BindingAdapter.kt
+++ b/core/ui/src/main/java/com/jslee/core/ui/binding/BindingAdapter.kt
@@ -77,6 +77,6 @@ fun ImageView.setBookmark(isBookmark: Boolean) {
 }
 
 @BindingAdapter("layoutVisibility")
-fun View.setLayoutVisibility(hasContent: Boolean) {
-    isVisible = hasContent
+fun View.setLayoutVisibility(isEmptyContent: Boolean) {
+    isVisible = !isEmptyContent
 }

--- a/domain/src/main/java/com/jslee/domain/model/movie/Movie.kt
+++ b/domain/src/main/java/com/jslee/domain/model/movie/Movie.kt
@@ -30,4 +30,6 @@ data class Movie(
     val casts: List<Cast>? = null,
     val staffs: List<Staff>? = null,
     val trailers: List<Trailer>? = null
-)
+) {
+    val isEmptyImages = images == emptyList<String>()
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/MovieDetailViewModel.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/MovieDetailViewModel.kt
@@ -15,8 +15,8 @@ import com.jslee.domain.usecase.bookmark.GetBookmarkUseCase
 import com.jslee.presentation.feature.detail.model.CastInfoUiModel
 import com.jslee.presentation.feature.detail.model.MovieDetailUiModel
 import com.jslee.presentation.feature.detail.model.item.DetailListItem
-import com.jslee.presentation.feature.detail.model.toDomain
-import com.jslee.presentation.feature.detail.model.toMovieDetailUiModel
+import com.jslee.presentation.feature.detail.model.mapper.toDomain
+import com.jslee.presentation.feature.detail.model.mapper.toMovieDetailUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/adapter/gallery/GalleryItemListAdapter.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/adapter/gallery/GalleryItemListAdapter.kt
@@ -21,6 +21,7 @@ class GalleryItemListAdapter : SingleViewTypeListAdapter<GalleryUiModel>({ it.id
     }
 
     override fun onBindViewHolder(holder: BaseViewHolder<GalleryUiModel>, position: Int) {
-        super.onBindViewHolder(holder, position)
+        val item = getItem(position) ?: return
+        holder.bindItems(item)
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/model/MovieDetailUiModel.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/model/MovieDetailUiModel.kt
@@ -3,6 +3,7 @@ package com.jslee.presentation.feature.detail.model
 import android.os.Parcelable
 import com.jslee.core.date.DateFormat
 import com.jslee.core.date.transformDate
+import com.jslee.core.ui.extension.emptyString
 import com.jslee.core.ui.extension.getSummaryInfo
 import com.jslee.presentation.feature.detail.model.item.DetailListItem
 import kotlinx.parcelize.Parcelize
@@ -64,7 +65,9 @@ data class MovieTrailerUiModel(
     val contentTitle: String,
     val description: String,
     val publishedDate: String,
-)
+) {
+    val isEmptyDescription = description == emptyString
+}
 
 data class RateUiModel(
     val tmdbRate: String,

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/model/MovieDetailUiModel.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/model/MovieDetailUiModel.kt
@@ -39,7 +39,10 @@ data class MovieInfoUiModel(
     val overview: String,
     val movieInfoData: List<MovieInfoItem>,
     val isOverviewExpanded: Boolean = false,
-)
+) {
+    val isTagLineEmpty = tagLine == emptyString
+    val isOverViewEmpty = overview == emptyString
+}
 
 data class MovieInfoItem(
     val title: String,

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/model/mapper/DetailListItemMapper.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/model/mapper/DetailListItemMapper.kt
@@ -1,0 +1,79 @@
+package com.jslee.presentation.feature.detail.model.mapper
+
+import com.jslee.domain.model.movie.Movie
+import com.jslee.presentation.feature.detail.model.item.DetailListItem
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/02/28
+ */
+
+
+private fun MutableList<DetailListItem>.addMovieInfoContents(movie: Movie) {
+    add(
+        DetailListItem.MovieInfo(
+            id = 0,
+            movieInfoData = movie.toMovieInfoUiModel()
+        )
+    )
+    add(
+        DetailListItem.Divider(
+            id = 1,
+        )
+    )
+}
+
+private fun MutableList<DetailListItem>.addRateInfoContents(movie: Movie) {
+    add(
+        DetailListItem.Rate(
+            id = 2,
+            rateData = movie.toRateUiModel()
+        )
+    )
+    add(
+        DetailListItem.Divider(
+            id = 3,
+        )
+    )
+}
+
+private fun MutableList<DetailListItem>.addCastInfoContents(
+    movie: Movie,
+) {
+    add(
+        DetailListItem.Cast(
+            id = 4,
+            castInfoData = movie.mapToCastInfoUiModel()
+        )
+    )
+    add(
+        DetailListItem.Divider(
+            id = 5,
+        )
+    )
+}
+
+private fun MutableList<DetailListItem>.addGalleryContents(movie: Movie) {
+    add(
+        DetailListItem.Gallery(
+            id = 6,
+            galleryData = movie.mapToGalleryUiModel()
+        )
+    )
+    add(
+        DetailListItem.Divider(
+            id = 7,
+        )
+    )
+}
+
+private fun MutableList<DetailListItem>.addTrailerContents(title: String, movie: Movie) {
+    add(
+        DetailListItem.MovieTrailer(
+            id = 8,
+            title = title,
+            trailerData = movie.mapToMovieTrailerUiModel()
+        )
+    )
+}

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/model/mapper/DetailListItemMapper.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/model/mapper/DetailListItemMapper.kt
@@ -9,6 +9,17 @@ import com.jslee.presentation.feature.detail.model.item.DetailListItem
  * @created 2024/02/28
  */
 
+fun Movie.toMovieDetailListItem(title: String): List<DetailListItem> {
+    val movieDetailContents = mutableListOf<DetailListItem>()
+
+    return movieDetailContents.apply {
+        addMovieInfoContents(this@toMovieDetailListItem)
+        addRateInfoContents(this@toMovieDetailListItem)
+        addCastInfoContents(this@toMovieDetailListItem)
+        if (!isEmptyImages) addGalleryContents(this@toMovieDetailListItem)
+        addTrailerContents(title, this@toMovieDetailListItem)
+    }
+}
 
 private fun MutableList<DetailListItem>.addMovieInfoContents(movie: Movie) {
     add(

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/model/mapper/MovieDetailMapper.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/model/mapper/MovieDetailMapper.kt
@@ -1,4 +1,4 @@
-package com.jslee.presentation.feature.detail.model
+package com.jslee.presentation.feature.detail.model.mapper
 
 import com.jslee.core.date.DateFormat
 import com.jslee.core.date.transformDate
@@ -7,7 +7,14 @@ import com.jslee.core.ui.extension.toDisplayRunTime
 import com.jslee.domain.model.movie.Certification
 import com.jslee.domain.model.movie.Movie
 import com.jslee.domain.model.movie.MovieStatus
-import com.jslee.presentation.feature.detail.model.item.DetailListItem
+import com.jslee.presentation.feature.detail.model.AppBarUiModel
+import com.jslee.presentation.feature.detail.model.CastInfoUiModel
+import com.jslee.presentation.feature.detail.model.GalleryUiModel
+import com.jslee.presentation.feature.detail.model.MovieDetailUiModel
+import com.jslee.presentation.feature.detail.model.MovieInfoItem
+import com.jslee.presentation.feature.detail.model.MovieInfoUiModel
+import com.jslee.presentation.feature.detail.model.MovieTrailerUiModel
+import com.jslee.presentation.feature.detail.model.RateUiModel
 
 /**
  * MooBeside
@@ -33,45 +40,6 @@ fun Movie.toAppBarModel() = AppBarUiModel(
 )
 
 const val SCREEN_SHOWN_LIMIT = 4
-fun Movie.toMovieDetailListItem(title: String) = listOf(
-    DetailListItem.MovieInfo(
-        id = 0,
-        movieInfoData = toMovieInfoUiModel()
-    ),
-    DetailListItem.Divider(
-        id = 1,
-    ),
-    DetailListItem.Rate(
-        id = 2,
-        rateData = toRateUiModel()
-    ),
-    DetailListItem.Divider(
-        id = 3,
-    ),
-    DetailListItem.Cast(
-        id = 4,
-        castInfoData = mapToCastInfoUiModel()
-    ),
-    DetailListItem.Divider(
-        id = 5,
-    ),
-    DetailListItem.Gallery(
-        id = 6,
-        galleryData = mapToGalleryUiModel()
-    ),
-    DetailListItem.Divider(
-        id = 7,
-    ),
-    DetailListItem.MovieTrailer(
-        id = 8,
-        title = title,
-        trailerData = mapToMovieTrailerUiModel()
-    ),
-    DetailListItem.Divider(
-        id = 9,
-    ),
-)
-
 fun Movie.toMovieInfoUiModel() = MovieInfoUiModel(
     tagLine = tagline.orEmpty(),
     overview = overview.orEmpty(),

--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/viewholder/cast/CastInfoViewHolder.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/viewholder/cast/CastInfoViewHolder.kt
@@ -3,7 +3,7 @@ package com.jslee.presentation.feature.detail.viewholder.cast
 import com.jslee.core.ui.base.BaseViewHolder
 import com.jslee.presentation.databinding.ItemDetailCastBinding
 import com.jslee.presentation.feature.detail.adapter.cast.CastInfoListAdapter
-import com.jslee.presentation.feature.detail.model.SCREEN_SHOWN_LIMIT
+import com.jslee.presentation.feature.detail.model.mapper.SCREEN_SHOWN_LIMIT
 import com.jslee.presentation.feature.detail.model.item.DetailListItem
 
 /**

--- a/presentation/src/main/res/layout/item_detail_info.xml
+++ b/presentation/src/main/res/layout/item_detail_info.xml
@@ -30,6 +30,7 @@
 
         <TextView
             android:id="@+id/tv_movie_tag"
+            layoutVisibility="@{movieInfo.isTagLineEmpty}"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
@@ -44,6 +45,7 @@
 
         <TextView
             android:id="@+id/tv_movie_overview"
+            layoutVisibility="@{movieInfo.isOverViewEmpty}"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
@@ -54,6 +56,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_movie_tag"
+            app:layout_goneMarginTop="12dp"
             tools:text="컴공과 아싸 추상우의 완벽하게 짜인 일상에 에러처럼 나타난 안하무인 디자인과 인싸 장재영, 극과 극 청춘들의 캠퍼스 로맨스가 스크린으로 펼쳐진다!" />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -69,6 +72,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_movie_overview"
+            app:layout_goneMarginTop="12dp"
             tools:listitem="@layout/item_movie_info" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/item_trailer.xml
+++ b/presentation/src/main/res/layout/item_trailer.xml
@@ -39,15 +39,15 @@
             android:maxLines="1"
             android:text="@{trailer.contentTitle}"
             android:textColor="@color/Black"
-            app:layout_constraintBottom_toTopOf="@id/tv_description"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/iv_thumbnail"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
             app:layout_constraintVertical_chainStyle="packed"
-            tools:text="[더 마블스] 파이널 예고편" />
+            tools:text="[더 마블스] 파이널 예고편 [더 마블스] 파이널 예고편 [더 마블스] 파이널 예고편" />
 
         <TextView
             android:id="@+id/tv_description"
+            layoutVisibility="@{trailer.isEmptyDescription}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
@@ -56,8 +56,7 @@
             android:text="@{trailer.description}"
             android:textColor="@color/Gray03"
             android:textSize="14sp"
-            app:layout_constraintBottom_toTopOf="@id/tv_published_date"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/tv_title"
             app:layout_constraintStart_toStartOf="@id/tv_title"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             app:layout_constraintVertical_chainStyle="packed"
@@ -71,11 +70,11 @@
             android:layout_marginTop="8dp"
             android:text="@{trailer.publishedDate}"
             android:textColor="@color/Gray06"
-            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/tv_description"
+            app:layout_constraintEnd_toEndOf="@id/tv_title"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
             app:layout_constraintTop_toBottomOf="@id/tv_description"
             app:layout_constraintVertical_chainStyle="packed"
+            app:layout_goneMarginTop="4dp"
             tools:text="2023년 10월 31일" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
### Issue
- close #138 

### 작업 내역 (Required)
- 기본정보 뷰타입 비어있는 값에 따른 visibility 처리
- 갤러리 뷰타입 데이터 비어있을 경우 visibility 처리
- 트레일러 뷰타입 비어있는 값에 따른 visibility 처리

### Screenshot
Before | After
:--: | :--:
<img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/be41df58-394c-4251-bbaa-a1e37f5aace6" width="300" /> | <img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/896c7f1a-6ae1-4c84-9f52-46cb38d52232" width="300" />

### 관련 링크
-