### PR TITLE
더보기 클릭시 전체 줄거리를 볼 수 있다

### DIFF
--- a/presentation/src/main/java/com/jslee/presentation/feature/detail/viewholder/info/MovieInfoViewHolder.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/detail/viewholder/info/MovieInfoViewHolder.kt
@@ -1,5 +1,8 @@
 package com.jslee.presentation.feature.detail.viewholder.info
 
+import android.text.TextUtils
+import androidx.core.view.doOnPreDraw
+import androidx.core.view.isVisible
 import com.jslee.core.ui.base.BaseViewHolder
 import com.jslee.core.ui.decoration.CommonItemDecoration
 import com.jslee.core.ui.decoration.LayoutType
@@ -13,6 +16,9 @@ import com.jslee.presentation.feature.detail.model.item.DetailListItem
  * @author jaesung
  * @created 2023/10/21
  */
+
+private const val COLLAPSED_OVERVIEW_LENGTH = 4
+
 class MovieInfoViewHolder(
     private val binding: ItemDetailInfoBinding,
 ) : BaseViewHolder<DetailListItem.MovieInfo>(binding) {
@@ -21,12 +27,39 @@ class MovieInfoViewHolder(
 
     init {
         initMovieInfoList()
+        setLoadMoreTextClickListener()
+        handleMovieOverviewExpandedState()
     }
 
     private fun initMovieInfoList() = with(binding.rvMovieInfo) {
         adapter = movieInfoListAdapter
         val paddingValues = PaddingValues.horizontal(0, 24)
         addItemDecoration(CommonItemDecoration(paddingValues, LayoutType.HORIZONTAL))
+    }
+
+    private fun handleMovieOverviewExpandedState() {
+        binding.tvMovieOverview.doOnPreDraw {
+            val lineCount = binding.tvMovieOverview.lineCount
+            if (lineCount > COLLAPSED_OVERVIEW_LENGTH) {
+                binding.tvMovieOverview.apply {
+                    ellipsize = TextUtils.TruncateAt.END
+                    maxLines = COLLAPSED_OVERVIEW_LENGTH
+                }
+                binding.tvLoadMore.isVisible = true
+            } else {
+                binding.tvLoadMore.isVisible = false
+            }
+        }
+    }
+
+    private fun setLoadMoreTextClickListener() {
+        binding.tvLoadMore.setOnClickListener { loadMoreText ->
+            loadMoreText.isVisible = false
+            binding.tvMovieOverview.apply {
+                ellipsize = null
+                maxLines = Int.MAX_VALUE
+            }
+        }
     }
 
     override fun bindItems(item: DetailListItem.MovieInfo) = with(binding) {

--- a/presentation/src/main/res/layout/item_detail_info.xml
+++ b/presentation/src/main/res/layout/item_detail_info.xml
@@ -59,6 +59,18 @@
             app:layout_goneMarginTop="12dp"
             tools:text="컴공과 아싸 추상우의 완벽하게 짜인 일상에 에러처럼 나타난 안하무인 디자인과 인싸 장재영, 극과 극 청춘들의 캠퍼스 로맨스가 스크린으로 펼쳐진다!" />
 
+        <TextView
+            android:id="@+id/tv_load_more"
+            style="@style/MooBesideTextAppearance.Caption1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/text_load_more"
+            android:textColor="@color/Gray06"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_movie_overview" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_movie_info"
             android:layout_width="0dp"
@@ -71,7 +83,7 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_movie_overview"
+            app:layout_constraintTop_toBottomOf="@id/tv_load_more"
             app:layout_goneMarginTop="12dp"
             tools:listitem="@layout/item_movie_info" />
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### Issue
- close #78 

### 작업 내역 (Required)
- 더보기 텍스트 버튼 뷰 추가
- 버튼 클릭 시 4줄로 제한된 줄거리 텍스트가 확장되어 모두 볼 수 있다.

### Screenshot
Before | After
:--: | :--:
<img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/91b01945-46ca-48ae-bf72-f1be74947bfd" width="300" /> | <img src="https://github.com/JaesungLeee/MooBeside/assets/51078673/33eef0df-d595-42b0-95ff-ccc3ad933c17" width="300" />

### 관련 링크
- none