### PR TITLE
각 스크린 별 NavigationBar visibility 책임 분리

### DIFF
--- a/presentation/src/main/java/com/jslee/presentation/Screen.kt
+++ b/presentation/src/main/java/com/jslee/presentation/Screen.kt
@@ -22,4 +22,17 @@ enum class Screen(@LayoutRes layoutId: Int, isNavigationBarVisible: Boolean) {
     SETTINGS_WEB_VIEW(R.layout.fragment_settings_web_view, false),
     SHARE_BOTTOM_SHEET(R.layout.dialog_share_bottom_sheet, false),
     FILTER_BOTTOM_SHEET(R.layout.dialog_filter_bottom_sheet, false);
+enum class Screen(val label: String, val isNavigationBarVisible: Boolean) {
+    HOME("HomeScreen", true),
+    BOX_OFFICE("BoxOfficeScreen", true),
+    BOOKMARK("BookmarkScreen", true),
+    UP_COMING("UpComingScreen", false),
+    NOW_PLAYING("NowPlayingScreen", false),
+    MOVIE_DETAIL("MovieDetailScreen", false),
+    CAST("CastScreen", false),
+    CAST_DETAIL("CastDetailScreen", false),
+    SEARCH("SearchScreen", false),
+    SETTINGS("SettingsScreen", false),
+    SETTINGS_DETAIL("SettingsDetailScreen", false),
+    SETTINGS_WEB_VIEW("SettingsWebViewScreen", false);
 }

--- a/presentation/src/main/java/com/jslee/presentation/Screen.kt
+++ b/presentation/src/main/java/com/jslee/presentation/Screen.kt
@@ -1,0 +1,25 @@
+package com.jslee.presentation
+
+import androidx.annotation.LayoutRes
+
+/**
+ * MooBeside
+ * @author jaesung
+ * @created 2024/03/05
+ */
+enum class Screen(@LayoutRes layoutId: Int, isNavigationBarVisible: Boolean) {
+    HOME(R.layout.fragment_home, true),
+    BOX_OFFICE(R.layout.fragment_box_office, true),
+    BOOKMARK(R.layout.fragment_bookmark, true),
+    UP_COMING(R.layout.fragment_up_coming, false),
+    NOW_PLAYING(R.layout.fragment_now_playing, false),
+    MOVIE_DETAIL(R.layout.fragment_movie_detail, false),
+    CAST(R.layout.fragment_cast, false),
+    CAST_DETAIL(R.layout.fragment_cast_detail, false),
+    SEARCH(R.layout.fragment_search, false),
+    SETTINGS(R.layout.fragment_settings, false),
+    SETTINGS_DETAIL(R.layout.fragment_settings_detail, false),
+    SETTINGS_WEB_VIEW(R.layout.fragment_settings_web_view, false),
+    SHARE_BOTTOM_SHEET(R.layout.dialog_share_bottom_sheet, false),
+    FILTER_BOTTOM_SHEET(R.layout.dialog_filter_bottom_sheet, false);
+}

--- a/presentation/src/main/java/com/jslee/presentation/Screen.kt
+++ b/presentation/src/main/java/com/jslee/presentation/Screen.kt
@@ -1,27 +1,10 @@
 package com.jslee.presentation
 
-import androidx.annotation.LayoutRes
-
 /**
  * MooBeside
  * @author jaesung
  * @created 2024/03/05
  */
-enum class Screen(@LayoutRes layoutId: Int, isNavigationBarVisible: Boolean) {
-    HOME(R.layout.fragment_home, true),
-    BOX_OFFICE(R.layout.fragment_box_office, true),
-    BOOKMARK(R.layout.fragment_bookmark, true),
-    UP_COMING(R.layout.fragment_up_coming, false),
-    NOW_PLAYING(R.layout.fragment_now_playing, false),
-    MOVIE_DETAIL(R.layout.fragment_movie_detail, false),
-    CAST(R.layout.fragment_cast, false),
-    CAST_DETAIL(R.layout.fragment_cast_detail, false),
-    SEARCH(R.layout.fragment_search, false),
-    SETTINGS(R.layout.fragment_settings, false),
-    SETTINGS_DETAIL(R.layout.fragment_settings_detail, false),
-    SETTINGS_WEB_VIEW(R.layout.fragment_settings_web_view, false),
-    SHARE_BOTTOM_SHEET(R.layout.dialog_share_bottom_sheet, false),
-    FILTER_BOTTOM_SHEET(R.layout.dialog_filter_bottom_sheet, false);
 enum class Screen(val label: String, val isNavigationBarVisible: Boolean) {
     HOME("HomeScreen", true),
     BOX_OFFICE("BoxOfficeScreen", true),
@@ -35,4 +18,41 @@ enum class Screen(val label: String, val isNavigationBarVisible: Boolean) {
     SETTINGS("SettingsScreen", false),
     SETTINGS_DETAIL("SettingsDetailScreen", false),
     SETTINGS_WEB_VIEW("SettingsWebViewScreen", false);
+
+    companion object {
+        fun getNavigationBarVisibility(screen: Screen): Boolean {
+            return when (screen) {
+                HOME -> HOME.isNavigationBarVisible
+                BOX_OFFICE -> BOX_OFFICE.isNavigationBarVisible
+                BOOKMARK -> BOOKMARK.isNavigationBarVisible
+                UP_COMING -> UP_COMING.isNavigationBarVisible
+                NOW_PLAYING -> NOW_PLAYING.isNavigationBarVisible
+                MOVIE_DETAIL -> MOVIE_DETAIL.isNavigationBarVisible
+                CAST -> CAST.isNavigationBarVisible
+                CAST_DETAIL -> CAST_DETAIL.isNavigationBarVisible
+                SEARCH -> SEARCH.isNavigationBarVisible
+                SETTINGS -> SETTINGS.isNavigationBarVisible
+                SETTINGS_DETAIL -> SETTINGS_DETAIL.isNavigationBarVisible
+                SETTINGS_WEB_VIEW -> SETTINGS_WEB_VIEW.isNavigationBarVisible
+            }
+        }
+
+        fun fromLabel(label: String): Screen? {
+            return when (label) {
+                HOME.label -> HOME
+                BOX_OFFICE.label -> BOX_OFFICE
+                BOOKMARK.label -> BOOKMARK
+                UP_COMING.label -> UP_COMING
+                NOW_PLAYING.label -> NOW_PLAYING
+                MOVIE_DETAIL.label -> MOVIE_DETAIL
+                CAST.label -> CAST
+                CAST_DETAIL.label -> CAST_DETAIL
+                SEARCH.label -> SEARCH
+                SETTINGS.label -> SETTINGS
+                SETTINGS_DETAIL.label -> SETTINGS_DETAIL
+                SETTINGS_WEB_VIEW.label -> SETTINGS_WEB_VIEW
+                else -> null
+            }
+        }
+    }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/MainActivity.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/MainActivity.kt
@@ -1,7 +1,10 @@
 package com.jslee.presentation.feature
 
-import android.view.View
 import androidx.activity.viewModels
+import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.jslee.core.logger.Logger
@@ -10,6 +13,8 @@ import com.jslee.presentation.R
 import com.jslee.presentation.databinding.ActivityMainBinding
 import com.jslee.presentation.feature.detail.MovieDetailFragmentDirections
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
@@ -23,14 +28,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         setDestinationChangeListener()
         initBottomNavigationView()
         handleDeepLinkNavigation()
+        observeStates()
     }
 
     private fun setDestinationChangeListener() {
         navController.addOnDestinationChangedListener { _, destination, _ ->
-            binding.bnvMain.visibility = when (destination.id) {
-                R.id.homeFragment, R.id.boxOfficeFragment, R.id.bookmarkFragment -> View.VISIBLE
-                else -> View.GONE
-            }
+            viewModel.setCurrentDestination("${destination.label}")
         }
     }
 
@@ -49,5 +52,15 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                 Logger.e(it)
             }
         )
+    }
+
+    private fun observeStates() {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.navBarVisibility.collectLatest { isVisible ->
+                    binding.bnvMain.isVisible = isVisible
+                }
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/jslee/presentation/feature/MainViewModel.kt
+++ b/presentation/src/main/java/com/jslee/presentation/feature/MainViewModel.kt
@@ -5,7 +5,11 @@ import androidx.lifecycle.ViewModel
 import com.jslee.core.deeplink.DeepLinkLauncher
 import com.jslee.core.deeplink.di.Firebase
 import com.jslee.core.deeplink.di.Kakao
+import com.jslee.presentation.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 /**
@@ -18,6 +22,18 @@ class MainViewModel @Inject constructor(
     @Firebase private val firebaseLauncher: DeepLinkLauncher,
     @Kakao private val kakaoLauncher: DeepLinkLauncher,
 ) : ViewModel() {
+
+    private val _navBarVisibility: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val navBarVisibility = _navBarVisibility.asStateFlow()
+
+    fun setCurrentDestination(label: String) {
+        val destination = Screen.fromLabel(label)
+        destination?.let { currentDestination ->
+            _navBarVisibility.update {
+                Screen.getNavigationBarVisibility(currentDestination)
+            }
+        }
+    }
 
     fun extractMovieIdFromDeepLink(
         intent: Intent,

--- a/presentation/src/main/res/navigation/navigation_bookmark.xml
+++ b/presentation/src/main/res/navigation/navigation_bookmark.xml
@@ -8,6 +8,6 @@
     <fragment
         android:id="@+id/bookmarkFragment"
         android:name="com.jslee.presentation.feature.bookmark.BookmarkFragment"
-        android:label="BookmarkFragment"
+        android:label="BookmarkScreen"
         tools:layout="@layout/fragment_bookmark" />
 </navigation>

--- a/presentation/src/main/res/navigation/navigation_bottom_bar.xml
+++ b/presentation/src/main/res/navigation/navigation_bottom_bar.xml
@@ -16,7 +16,7 @@
     <fragment
         android:id="@+id/movieDetailFragment"
         android:name="com.jslee.presentation.feature.detail.MovieDetailFragment"
-        android:label="MovieDetailFragment"
+        android:label="MovieDetailScreen"
         tools:layout="@layout/fragment_movie_detail">
 
         <deepLink
@@ -38,7 +38,7 @@
     <fragment
         android:id="@+id/castFragment"
         android:name="com.jslee.presentation.feature.cast.CastFragment"
-        android:label="CastFragment"
+        android:label="CastScreen"
         tools:layout="@layout/fragment_cast">
         <argument
             android:name="casts"
@@ -50,7 +50,7 @@
     <fragment
         android:id="@+id/castDetailFragment"
         android:name="com.jslee.presentation.feature.castdetail.CastDetailFragment"
-        android:label="CastDetailFragment">
+        android:label="CastDetailScreen">
         <argument
             android:name="personId"
             app:argType="long" />

--- a/presentation/src/main/res/navigation/navigation_box_office.xml
+++ b/presentation/src/main/res/navigation/navigation_box_office.xml
@@ -8,6 +8,6 @@
     <fragment
         android:id="@+id/boxOfficeFragment"
         android:name="com.jslee.presentation.feature.boxoffice.BoxOfficeFragment"
-        android:label="BoxOfficeFragment"
+        android:label="BoxOfficeScreen"
         tools:layout="@layout/fragment_box_office" />
 </navigation>

--- a/presentation/src/main/res/navigation/navigation_home.xml
+++ b/presentation/src/main/res/navigation/navigation_home.xml
@@ -7,7 +7,7 @@
     <fragment
         android:id="@+id/homeFragment"
         android:name="com.jslee.presentation.feature.home.HomeFragment"
-        android:label="HomeFragment">
+        android:label="HomeScreen">
         <action
             android:id="@+id/action_home_to_search"
             app:destination="@id/searchFragment" />
@@ -25,11 +25,11 @@
     <fragment
         android:id="@+id/searchFragment"
         android:name="com.jslee.presentation.feature.search.SearchFragment"
-        android:label="SearchFragment" />
+        android:label="SearchScreen" />
     <fragment
         android:id="@+id/settingsFragment"
         android:name="com.jslee.presentation.feature.settings.SettingsFragment"
-        android:label="SettingsFragment">
+        android:label="SettingsScreen">
         <action
             android:id="@+id/action_settings_to_settingsDetail"
             app:destination="@id/settingsDetailFragment" />
@@ -40,15 +40,15 @@
     <fragment
         android:id="@+id/nowPlayingFragment"
         android:name="com.jslee.presentation.feature.now.NowPlayingFragment"
-        android:label="NowPlayingFragment" />
+        android:label="NowPlayingScreen" />
     <fragment
         android:id="@+id/upComingFragment"
         android:name="com.jslee.presentation.feature.upcoming.UpComingFragment"
-        android:label="UpComingFragment" />
+        android:label="UpComingScreen" />
     <fragment
         android:id="@+id/settingsDetailFragment"
         android:name="com.jslee.presentation.feature.settings.SettingsDetailFragment"
-        android:label="SettingsDetailFragment">
+        android:label="SettingsDetailScreen">
         <argument
             android:name="navigationOption"
             app:argType="com.jslee.presentation.feature.settings.model.navigation.NavigationOption" />
@@ -56,7 +56,7 @@
     <fragment
         android:id="@+id/settingsWebViewFragment"
         android:name="com.jslee.presentation.feature.settings.SettingsWebViewFragment"
-        android:label="SettingsWebViewFragment">
+        android:label="SettingsWebViewScreen">
         <argument
             android:name="navigationOption"
             app:argType="com.jslee.presentation.feature.settings.model.navigation.NavigationOption" />


### PR DESCRIPTION
### Issue
- close #145 

### 작업 내역 (Required)
- Screen enum 모델링
- 스크린 별 NavigationBar visibility 제어를 view의 책임에서 viewmodel 책임으로 이동 및 분리
- navigation graph 각 destination들의 라벨 수정

### 관련 링크
- none