### PR TITLE
#170 migrate kapt to ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,10 +8,10 @@ plugins {
 android {
     namespace = "com.jslee.moobeside"
 
-//    buildFeatures {
-//        dataBinding = true
-//        buildConfig = true
-//    }
+    buildFeatures {
+        dataBinding = true
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.hilt.plugin) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+//    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.ksp) apply false
     alias(libs.plugins.firebase.crashlytics.plugin) apply false
 }

--- a/core/common/ui/build.gradle.kts
+++ b/core/common/ui/build.gradle.kts
@@ -1,10 +1,14 @@
 plugins {
     alias(libs.plugins.moobeside.android.library.compose)
-    alias(libs.plugins.kotlin.kapt)
+    id("org.jetbrains.kotlin.kapt")
 }
 
-android {
+android{
     namespace = "com.moobeside.core.common.ui"
+
+    buildFeatures {
+        dataBinding = true
+    }
 }
 
 dependencies {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.moobeside.android.library)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt.plugin)
 }
@@ -27,7 +27,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.timber)
 }

--- a/core/deeplink/build.gradle.kts
+++ b/core/deeplink/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.moobeside.android.library)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.hilt.plugin)
 }
 
@@ -10,7 +10,7 @@ android {
 
 dependencies {
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.dynaimc.link)

--- a/core/external/build.gradle.kts
+++ b/core/external/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.moobeside.android.library)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.hilt.plugin)
 }
 
@@ -10,5 +10,5 @@ android {
 
 dependencies {
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 }

--- a/core/image/build.gradle.kts
+++ b/core/image/build.gradle.kts
@@ -1,17 +1,22 @@
 plugins {
     alias(libs.plugins.moobeside.android.library)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
+    id("org.jetbrains.kotlin.kapt")
 }
 
-android {
+android{
     namespace = "com.jslee.core.image"
+
+    buildFeatures {
+        dataBinding = true
+    }
 }
 
 dependencies {
     implementation(projects.core.designsystem)
 
     implementation(libs.glide)
-    kapt(libs.glide.compiler)
+    ksp(libs.glide.ksp)
 
     implementation(libs.facebook.shimmer)
 }

--- a/core/local/build.gradle.kts
+++ b/core/local/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.moobeside.android.library)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt.plugin)
 }
@@ -17,10 +17,10 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.bundles.androidx.room)
-    kapt(libs.androidx.room.compiler)  // migrate to ksp
+    ksp(libs.androidx.room.compiler)  // migrate to ksp
 
     implementation(libs.timber)
 }

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -2,7 +2,7 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
 plugins {
     alias(libs.plugins.moobeside.android.library)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt.plugin)
 }
@@ -38,7 +38,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.timber)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ retrofit = "2.9.0"
 okhttp = "4.10.0"
 
 # 3rd party
-glide = "4.13.2"
+glide = "4.14.2"
 timber = "5.0.1"
 retrofit2-kotlinx-serialization-conveter = "0.8.0"
 balloon = "1.5.4"
@@ -125,7 +125,7 @@ logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-intercep
 
 # glide
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
-glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
+glide-ksp = { group = "com.github.bumptech.glide", name = "ksp", version.ref = "glide" }
 
 # logger
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.moobeside.android.library.compose)
     alias(libs.plugins.moobeside.android.hilt)
+    id("org.jetbrains.kotlin.kapt")
     id("androidx.navigation.safeargs.kotlin")
     id("kotlin-parcelize")
 }


### PR DESCRIPTION
### Issue
- close #170 

### 작업 내역 (Required)
- Glide 4.14.2 ksp migration (https://bumptech.github.io/glide/doc/download-setup.html#kotlin---ksp)
- enable kapt for legacy databinding

### 관련 링크
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 시스템 최적화를 위해 Kotlin 어노테이션 처리 도구를 업그레이드했습니다.
  * Glide를 4.13.2에서 4.14.2로 업데이트했습니다.
  * 데이터 바인딩 기능을 활성화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->